### PR TITLE
Additional loader features; fix #16, #11, #13

### DIFF
--- a/Bundles/Alt-Zoom/Makefile
+++ b/Bundles/Alt-Zoom/Makefile
@@ -96,3 +96,8 @@ install: all
 	sudo cp -rf build/Alt-Zoom.app /Applications/
 	sudo rm -rf /Library/Apple/System/Library/Frameworks/mip/Bundles/Alt-Zoom.bundle
 	sudo cp -rf build/Alt-Zoom.bundle /Library/Apple/System/Library/Frameworks/mip/Bundles/
+
+uninstall:
+	sudo rm -rf /Library/Apple/System/Library/Frameworks/mip/Bundles/Alt-Zoom.bundle
+	sudo rm -rf /Applications/Alt-Zoom.app
+	

--- a/Bundles/Alt-Zoom/Makefile
+++ b/Bundles/Alt-Zoom/Makefile
@@ -28,7 +28,8 @@ BUNDLE_LDFLAGS += -arch i386
 endif
 endif
 
-SIGN_IDENTITY ?= "CodeSign"
+SIGN_IDENTITY ?= CodeSign
+CODESIGN_TARGET := codesign -fs "$(SIGN_IDENTITY)"
 
 BUNDLE_SOURCES := $(shell ls bundle/*.m)
 SETTINGS_SOURCES := $(shell ls settings/*.m)
@@ -56,12 +57,12 @@ build/bundle/%.o: bundle/%
 	$(CC) $(BUNDLE_CFLAGS) -fobjc-arc -c $< -o $@
 
 build/Alt-Zoom.bundle: build/Alt-Zoom.bundle/Contents/MacOS/Alt-Zoom build/Alt-Zoom.bundle/Contents/Info.plist
-	codesign -fs $(SIGN_IDENTITY) $@
+	$(CODESIGN_TARGET) $@
 build/Alt-Zoom.app: build/Alt-Zoom.app/Contents/MacOS/Alt-Zoom\
                     build/Alt-Zoom.app/Contents/Info.plist\
                     build/Alt-Zoom.app/Contents/Resources/Base.lproj/MainMenu.nib\
                     build/Alt-Zoom.app/Contents/Resources/AppIcon.icns
-	codesign -fs $(SIGN_IDENTITY) $@
+	$(CODESIGN_TARGET) $@
 
 build/Alt-Zoom.bundle/Contents/MacOS/Alt-Zoom: $(BUNDLE_OBJECTS)
 	-@mkdir -p $(dir $@)

--- a/Bundles/Alt-Zoom/bundle/Info.plist
+++ b/Bundles/Alt-Zoom/bundle/Info.plist
@@ -3,11 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>MIPUseBlacklistMode</key>
-	<true/>
-	<key>MIPExecutableNames</key>
+	<false/>
+	<key>MIPBundleNames</key>
 	<array>
-		<string>Dock</string>
+		<string>com.apple.AppKit</string>
 	</array>
+	<key>MIPExcludedBundleNames</key>
+	<array>
+		<string>com.apple.dock</string>
+	</array>
+	
 	<key>CFBundleExecutable</key>
 	<string>Alt-Zoom</string>
 	<key>CFBundleIdentifier</key>

--- a/MIP/Makefile
+++ b/MIP/Makefile
@@ -15,6 +15,7 @@ ARCH2 := i386
 endif
 
 SIGN_IDENTITY ?= CodeSign
+CODESIGN_TARGET := codesign -s "$(SIGN_IDENTITY)"
 
 all: build/lsdinjector.dylib build/loader.dylib build/inject local.lsdinjector.plist
 
@@ -24,16 +25,16 @@ build/lsdinjector.dylib: build/injector/lsd_injector.c.o \
 								  build/injector/hook/thread_locking.c.o \
 								  build/injector/injector.o
 	$(CC) $(LDFLAGS) -arch $(ARCH1) $^ -framework CoreSymbolication -lbsm -shared -o $@
-	codesign -s "$(SIGN_IDENTITY)" $@
+	$(CODESIGN_TARGET) $@
 
 build/loader.dylib: loader/loader.m
 	$(CC) $(CFLAGS) $(LDFLAGS) -install_name /Library/Apple/System/Library/Frameworks/mip/loader.dylib -framework Foundation -shared -arch $(ARCH1) -arch $(ARCH2) $< -o $@
-	codesign -s "$(SIGN_IDENTITY)" $@
+	$(CODESIGN_TARGET) $@
 
 build/inject: build/injector/injector.o build/injector/main.c.o
 	mkdir -p $(dir $@)
 	$(CC) $(LDFLAGS) $^ -o $@ -arch $(ARCH1)
-	codesign -s "$(SIGN_IDENTITY)" $@
+	$(CODESIGN_TARGET) $@
 
 build/injector/injector.o: build/injector/inject/inject.c.o build/injector/payloads/injected_$(ARCH1).c.bin build/injector/payloads/injected_$(ARCH2).c.bin 
 	ld -r $(filter %.o,$^) -o $@ -sectcreate __INJ_$(ARCH1) __inj_$(ARCH1) build/injector/payloads/injected_$(ARCH1).c.bin -sectcreate __INJ_$(ARCH2) __inj_$(ARCH2) build/injector/payloads/injected_$(ARCH2).c.bin

--- a/MIP/Makefile
+++ b/MIP/Makefile
@@ -14,7 +14,7 @@ ARCH1 := x86_64
 ARCH2 := i386
 endif
 
-SIGN_IDENTITY ?= "CodeSign"
+SIGN_IDENTITY ?= CodeSign
 
 all: build/lsdinjector.dylib build/loader.dylib build/inject local.lsdinjector.plist
 
@@ -24,16 +24,16 @@ build/lsdinjector.dylib: build/injector/lsd_injector.c.o \
 								  build/injector/hook/thread_locking.c.o \
 								  build/injector/injector.o
 	$(CC) $(LDFLAGS) -arch $(ARCH1) $^ -framework CoreSymbolication -lbsm -shared -o $@
-	codesign -s $(SIGN_IDENTITY) $@
+	codesign -s "$(SIGN_IDENTITY)" $@
 
 build/loader.dylib: loader/loader.m
 	$(CC) $(CFLAGS) $(LDFLAGS) -install_name /Library/Apple/System/Library/Frameworks/mip/loader.dylib -framework Foundation -shared -arch $(ARCH1) -arch $(ARCH2) $< -o $@
-	codesign -s $(SIGN_IDENTITY) $@
+	codesign -s "$(SIGN_IDENTITY)" $@
 
 build/inject: build/injector/injector.o build/injector/main.c.o
 	mkdir -p $(dir $@)
 	$(CC) $(LDFLAGS) $^ -o $@ -arch $(ARCH1)
-	codesign -s $(SIGN_IDENTITY) $@
+	codesign -s "$(SIGN_IDENTITY)" $@
 
 build/injector/injector.o: build/injector/inject/inject.c.o build/injector/payloads/injected_$(ARCH1).c.bin build/injector/payloads/injected_$(ARCH2).c.bin 
 	ld -r $(filter %.o,$^) -o $@ -sectcreate __INJ_$(ARCH1) __inj_$(ARCH1) build/injector/payloads/injected_$(ARCH1).c.bin -sectcreate __INJ_$(ARCH2) __inj_$(ARCH2) build/injector/payloads/injected_$(ARCH2).c.bin

--- a/MIP/loader/loader.m
+++ b/MIP/loader/loader.m
@@ -23,15 +23,23 @@ const char *MIP_user_data_path(void)
 BOOL should_inject_bundle(
     NSBundle *tweakBundle,
     NSString *mainExecutableName,
-    NSArray<NSString *> *disabled_bundles
+    NSArray<NSString *> *globalyDisabledBundles
 ) {
     NSDictionary *plist = tweakBundle.infoDictionary;
     BOOL blacklistMode = [plist[@"MIPUseBlacklistMode"] boolValue];
     
     // Skip tweak if it is globally disabled
-    if ([disabled_bundles containsObject:tweakBundle.bundleIdentifier]) {
+    if ([globalyDisabledBundles containsObject:tweakBundle.bundleIdentifier]) {
         // Not affected by blacklist mode
         return NO;
+    }
+    
+    // Skip tweak if a matching bundle is excluded
+    for (NSString *entry in plist[@"MIPExcludedBundleNames"]) {
+        if (CFBundleGetBundleWithIdentifier((CFStringRef)entry)) {
+            // Match found; skip loading
+            return NO;
+        }
     }
     
     // Check if process matches bundle filter

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ MIP includes Alt-Zoom as both a useful tweak and a bundle development reference.
 ## Injection Filters
 The processes a bundle is loaded into are determined by that bundle's `Info.plist` file. By default MIP filters in a white-list manner. The following keys are used to control filtering:
 
- * `MIPBundleNames` - Array, controls the bundle names to inject to (or to ignore in black-list mode).
+ * `MIPBundleNames` - Array, lists bundle names to inject alongside (or to ignore in black-list mode).
+    * This can be either an app or framework bundle identifier, such as `com.apple.AppKit`
+ * `MIPExcludedBundleNames` - Array, lists bundle names to _never_ inject alongside.
+    * Takes precedence over all other filters
+    * Not affected by black-list mode
  * `MIPExecutableNames` - Array, controls the executable basenames to inject to (or to ignore in black-list mode).
  * `MIPUseBlacklistMode` - Boolean, sets the filtering mode to black-list mode if true.
  * `MIPSupportsGC` - Boolean, tells MIP the injected bundle supports Garbage Collection and may be injected to GC-enabled processes. If incorrectly set to true while the injected bundle does not actually support GC, the injected bundle will crash the process. Garbage Collection is not available in macOS Sierra's Objective-C runtime, no need to support it if you're targeting Sierra and newer.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MIP has the following advantages when comparing to other injection techniques:
 ## How To Compile
 You will need Xcode's command-line tools, as well as binutils for `gobjcopy` (`brew install binutils`), which should be linked as `gobjcopy`. You will also need a signing identity, which may be self-signed. Not signing MIP binaries properly will make your system unstable! On Intel Macs, you will need the [10.13 SDK](https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.13.sdk.tar.xz), to compile the 32-bit portions of MIP.
 
-To compile, simply run `make SIGNING_IDENTITY=<codesign identity>` inside the MIP folder, or `make SYSROOT=path/to/MacOSX10.13.sdk SIGNING_IDENTITY=<codesign identity>` on Intel Macs.
+To compile, simply run `make SIGN_IDENTITY=<codesign identity>` inside the MIP folder, or `make SYSROOT=path/to/MacOSX10.13.sdk SIGN_IDENTITY=<codesign identity>` on Intel Macs.
 
 ## How To Install/Uninstall
 MIP requires disabling SIP (System Integrity Protection) both during installation and during use. On ARM64 Macs, you will also need to enable the arm64e preview ABI (`sudo nvram boot-args=-arm64e_preview_abi`)
@@ -39,7 +39,7 @@ SIP not only prevents system files and folders from being modified, but also pre
 In El Capitan, MIP can be modified to run with SIP enabled as long as it was disabled during installation, due to task ports being leaked to launchservicesd via XPC messages, but this is neither recommended nor supported, and requires modifying launchservicesd's launchd plist file. This potential vulnerability was fixed in Sierra.
 
 ## Sample Bundles
-MIP includes Alt-Zoom as both a useful tweak and a bundle development reference. Alt-Zoom is a bundle that lets you modify the default behavior of the zoom button and the way modifier keys affect its behavior. You can install it by running `make SIGNING_IDENTITY=<codesign identity>` and `make install` in Alt-Zoom's folder in the repository. It has a setting app to control its configuration.
+MIP includes Alt-Zoom as both a useful tweak and a bundle development reference. Alt-Zoom is a bundle that lets you modify the default behavior of the zoom button and the way modifier keys affect its behavior. You can install it by running `make SIGN_IDENTITY=<codesign identity>` and `make install` in Alt-Zoom's folder in the repository. It has a setting app to control its configuration.
 
 ## Injection Filters
 The processes a bundle is loaded into are determined by that bundle's `Info.plist` file. By default MIP filters in a white-list manner. The following keys are used to control filtering:


### PR DESCRIPTION
This PR adds two new features:

1. Link tweaks against any loadable bundle, not just the main bundle
    - Allows loading into all AppKit apps with just `com.apple.AppKit`
2. Adds a `MIPExcludedBundleNames` filter key
    - Allows for more "correct" hooking of UI apps where you want to exclude something like the Dock. Previously you would have to enable blacklist mode and exclude the dock/other processes, but your tweak would still load into pretty much every other process, which is not ideal. This way you can specify AppKit as the target bundle and exclude the dock.
        - Updated example project to reflect this change

This PR also adds an `uninstall` target to the example project's makefile